### PR TITLE
Support different bracket types

### DIFF
--- a/src/Snail/Characters.hs
+++ b/src/Snail/Characters.hs
@@ -6,7 +6,7 @@ initialCharacter = ['a' .. 'z'] <> ['A' .. 'Z']
 
 -- | ...
 specialInitialCharacter :: String
-specialInitialCharacter = "!$%&*/:<=>?^_~#,'"
+specialInitialCharacter = "!$%&*/:=?^_~#,'"
 
 -- | ...
 peculiarCharacter :: String
@@ -18,7 +18,7 @@ digitCharacter = ['0' .. '9']
 
 -- | ...
 specialSubsequentCharacter :: String
-specialSubsequentCharacter = "+-.@\\"
+specialSubsequentCharacter = "+-.@\\<>"
 
 -- | ...
 parenthesisStartingCharacter :: String

--- a/src/Snail/Characters.hs
+++ b/src/Snail/Characters.hs
@@ -1,25 +1,28 @@
-module Snail.Characters where
+module Snail.Characters (initialCharacter, subsequentCharacter, parenthesisStartingCharacter) where
 
 -- | The initial character of any text
 initialCharacter :: String
-initialCharacter = ['a' .. 'z'] <> ['A' .. 'Z']
+initialCharacter = ['a' .. 'z'] <> ['A' .. 'Z'] <> digitCharacter <> specialInitialCharacter
 
--- | ...
-specialInitialCharacter :: String
-specialInitialCharacter = "!$%&*/:=?^_~#,'"
+{- | The subsequent characters allowed in any text
 
--- | ...
-peculiarCharacter :: String
-peculiarCharacter = "+-."
+Allows `(-<>)` but not `(<>)`
+-}
+subsequentCharacter :: String
+subsequentCharacter = initialCharacter <> specialSubsequentCharacter
 
--- | ...
+-- | Characters allowed in numbers
 digitCharacter :: String
 digitCharacter = ['0' .. '9']
 
--- | ...
-specialSubsequentCharacter :: String
-specialSubsequentCharacter = "+-.@\\<>"
+-- | Special initial characters
+specialInitialCharacter :: String
+specialInitialCharacter = "!$%&*/:=?^_~#,'+-.@\\<>"
 
--- | ...
+-- | Additional subsequent characters
+specialSubsequentCharacter :: String
+specialSubsequentCharacter = "<>"
+
+-- | Characters allowed in front of an s-expression
 parenthesisStartingCharacter :: String
 parenthesisStartingCharacter = "'`@#,"

--- a/src/Snail/Characters.hs
+++ b/src/Snail/Characters.hs
@@ -1,15 +1,8 @@
-module Snail.Characters (initialCharacter, subsequentCharacter, parenthesisStartingCharacter) where
+module Snail.Characters (validCharacter, parenthesisStartingCharacter) where
 
--- | The initial character of any text
-initialCharacter :: String
-initialCharacter = ['a' .. 'z'] <> ['A' .. 'Z'] <> digitCharacter <> specialInitialCharacter
-
-{- | The subsequent characters allowed in any text
-
-Allows `(-<>)` but not `(<>)`
--}
-subsequentCharacter :: String
-subsequentCharacter = initialCharacter <> specialSubsequentCharacter
+-- | The valid character set of Snail
+validCharacter :: String
+validCharacter = ['a' .. 'z'] <> ['A' .. 'Z'] <> digitCharacter <> specialInitialCharacter
 
 -- | Characters allowed in numbers
 digitCharacter :: String
@@ -18,10 +11,6 @@ digitCharacter = ['0' .. '9']
 -- | Special initial characters
 specialInitialCharacter :: String
 specialInitialCharacter = "!$%&*/:=?^_~#,'+-.@\\<>"
-
--- | Additional subsequent characters
-specialSubsequentCharacter :: String
-specialSubsequentCharacter = "<>"
 
 -- | Characters allowed in front of an s-expression
 parenthesisStartingCharacter :: String

--- a/src/Snail/Lexer.hs
+++ b/src/Snail/Lexer.hs
@@ -113,9 +113,8 @@ data SnailAst
 lexeme :: Parser SnailAst
 lexeme = do
     sourcePosition <- getSourcePos
-    initial <- oneOf initialCharacter
-    rest <- many $ oneOf subsequentCharacter
-    pure $ Lexeme (sourcePosition, Text.pack $ initial : rest)
+    txt <- some $ oneOf validCharacter
+    pure $ Lexeme (sourcePosition, Text.pack txt)
 
 -- | An escaped quote to support nesting `"` inside a 'textLiteral'
 escapedQuote :: Parser Text
@@ -143,7 +142,7 @@ textLiteral :: Parser SnailAst
 textLiteral = do
     sourcePosition <- getSourcePos
     mText <- quotes . optional $ some $ escapedQuote <|> nonQuoteCharacter
-    notFollowedBy (oneOf subsequentCharacter <|> char '\"')
+    notFollowedBy (oneOf validCharacter <|> char '\"')
     pure $ case mText of
         Nothing -> TextLiteral (sourcePosition, "")
         Just text -> TextLiteral (sourcePosition, Text.concat text)

--- a/src/Snail/ToText.hs
+++ b/src/Snail/ToText.hs
@@ -3,13 +3,20 @@ module Snail.ToText (toText) where
 import Data.Text
 import Snail.Lexer
 
+bracket :: Text -> Bracket -> Text
+bracket txt = \case
+    Round -> "(" <> txt <> ")"
+    Square -> "[" <> txt <> "]"
+    Curly -> "{" <> txt <> "}"
+    Angle -> "<" <> txt <> ">"
+
 toText :: SnailAst -> Text
 toText = \case
     TextLiteral (_, txt) -> "\"" <> txt <> "\""
     Lexeme (_, lexeme) -> lexeme
-    SExpression Nothing exprs ->
+    SExpression Nothing bracketKind exprs ->
         let txt = Data.Text.unwords $ toText <$> exprs
-         in "(" <> txt <> ")"
-    SExpression (Just c) exprs ->
+         in bracket txt bracketKind
+    SExpression (Just c) bracketKind exprs ->
         let txt = Data.Text.unwords $ toText <$> exprs
-         in singleton c <> "(" <> txt <> ")"
+         in singleton c <> bracket txt bracketKind

--- a/src/Snail/ToText.hs
+++ b/src/Snail/ToText.hs
@@ -8,7 +8,6 @@ bracket txt = \case
     Round -> "(" <> txt <> ")"
     Square -> "[" <> txt <> "]"
     Curly -> "{" <> txt <> "}"
-    Angle -> "<" <> txt <> ">"
 
 toText :: SnailAst -> Text
 toText = \case

--- a/test/Snail/LexerSpec.hs
+++ b/test/Snail/LexerSpec.hs
@@ -7,7 +7,7 @@ import Data.Text
 import Snail
 import Test.HUnit (assertBool)
 import Test.Hspec
-import Text.Megaparsec (parseMaybe)
+import Text.Megaparsec (parseMaybe, parseTest)
 import Text.RawString.QQ
 
 foldLexemes :: SnailAst -> [Text]
@@ -28,7 +28,7 @@ failAssertion s = assertBool s False
 sExpressionShouldBe :: Text -> [Text] -> Expectation
 sExpressionShouldBe input output =
     case parseMaybe sExpression input of
-        Nothing -> failAssertion "sExpressionShouldBe: Nothing"
+        Nothing -> failAssertion $ "sExpressionShouldBe: " <> unpack input
         Just sExpr -> do
             let lexemes = foldLexemes sExpr
             lexemes `shouldBe` output
@@ -79,10 +79,11 @@ spec = do
             let mSExpr = parseMaybe sExpression "nil"
             mSExpr `shouldSatisfy` isNothing
 
-        it "successfully lex a basic list" $ do
+        it "successfully lex a basic list with number" $ do
+            parseTest sExpression "(1 a)"
             "(1 a)" `sExpressionShouldBe` ["1", "a"]
 
-        it "successfully lex a basic list with starting character" $ do
+        it "successfully lex a basic list with number and starting character" $ do
             "'(1 a)" `sExpressionShouldBe` ["1", "a"]
 
         it "successfully lex a single element list" $ do
@@ -98,16 +99,16 @@ spec = do
             "(() ())" `sExpressionShouldBe` []
 
         it "successfully lex nested s-expressions of each bracket" $ do
-            "(() [] <> {})" `sExpressionShouldBe` []
+            "(() [] {})" `sExpressionShouldBe` []
 
         it "successfully lex internally nested s-expressions of each bracket" $ do
-            "([<{}>])" `sExpressionShouldBe` []
+            "([{}])" `sExpressionShouldBe` []
 
         it "successfully lex a nested s-expressions" $ do
             "((()) (()))" `sExpressionShouldBe` []
 
         it "successfully lex a nested s-expressions of different brackets" $ do
-            "(<()> <{}>)" `sExpressionShouldBe` []
+            "({()} [{}])" `sExpressionShouldBe` []
 
         it "successfully lex line comment" $ do
             "(-- ...\n)" `sExpressionShouldBe` []

--- a/test/Snail/ToTextSpec.hs
+++ b/test/Snail/ToTextSpec.hs
@@ -11,14 +11,15 @@ spec :: Spec
 spec = do
     describe "toText" $ do
         it "handles empty s-expression" $
-            toText (SExpression Nothing []) `shouldBe` "()"
+            toText (SExpression Nothing Round []) `shouldBe` "()"
         it "handles basic text literal" $
-            toText (SExpression Nothing [TextLiteral (sourcePos, "hello world")])
+            toText (SExpression Nothing Round [TextLiteral (sourcePos, "hello world")])
                 `shouldBe` [r|("hello world")|]
         it "handles basic lexeme" $
             toText
                 ( SExpression
                     Nothing
+                    Round
                     [ Lexeme (sourcePos, "hello")
                     , Lexeme (sourcePos, "world")
                     ]


### PR DESCRIPTION
Ideally, we could support `(let [x 1] x)` as valid snail