### PR TITLE
Move AST to single file; add unwrap utility

### DIFF
--- a/snail.cabal
+++ b/snail.cabal
@@ -41,6 +41,7 @@ source-repository head
 library
   exposed-modules:
       Snail
+      Snail.Ast
       Snail.Characters
       Snail.IO
       Snail.Lexer

--- a/src/Snail.hs
+++ b/src/Snail.hs
@@ -2,6 +2,7 @@ module Snail (
     module X,
 ) where
 
+import Snail.Ast as X
 import Snail.Characters as X
 import Snail.IO as X
 import Snail.Lexer as X

--- a/src/Snail/Ast.hs
+++ b/src/Snail/Ast.hs
@@ -1,0 +1,62 @@
+module Snail.Ast (
+    -- * Constructors for AST
+    Bracket (..),
+    SnailAst (..),
+) where
+
+import Data.Text (Text)
+import Text.Megaparsec
+
+-- | The bracket used to surround the s-expression
+data Bracket
+    = Round
+    | Square
+    | Curly
+    deriving (Show, Eq)
+
+{-
+    A possibly empty tree of s-expressions
+
+    Technically,
+    @
+    Token (SourcePos {..}, "hello")
+    @
+
+    isn't a valid s-expression. This is,
+
+    @
+    SExpression [Token (SourcePos {..}, "hello")]
+    @
+
+    and this is also valid,
+
+    @
+    SExpression []
+    @
+
+    The 'Data.Tree.Tree' type in containers is non-empty which isn't exactly what we are looking for
+-}
+data SnailAst
+    = Lexeme (SourcePos, Text)
+    | TextLiteral (SourcePos, Text)
+    | SExpression (Maybe Char) Bracket [SnailAst]
+    deriving (Eq, Show)
+
+{- | Unwrap nested s-expressions, this is very useful when you are converting
+'SnailAst' to your own AST.
+
+You'll likely have a function `snailAstToMyAst :: SnailAst -> m MyAst` where
+`m` is `ExceptT` or `MonadExcept`. Then, your final case statement should
+unwrap nested expressions to their base with,
+
+@
+snailAstToMyAst . unwrap . SExpression initialChar bracket $ unwrap <$> exprs`
+@
+
+For example, `((read))` will become `SExpression _ _ [Lexeme (_, "read")]`
+which your AST converter should handle.
+-}
+unwrap :: SnailAst -> SnailAst
+unwrap = \case
+    SExpression _ _ [x] -> x
+    x -> x

--- a/src/Snail/IO.hs
+++ b/src/Snail/IO.hs
@@ -3,6 +3,7 @@ module Snail.IO where
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
+import Snail.Ast
 import Snail.Lexer
 import Text.Megaparsec
 

--- a/src/Snail/Lexer.hs
+++ b/src/Snail/Lexer.hs
@@ -10,9 +10,6 @@
 {-# LANGUAGE TupleSections #-}
 
 module Snail.Lexer (
-    -- * The parsers you should use
-    SnailAst (..),
-    Bracket (..),
     sExpression,
     snailAst,
 
@@ -24,6 +21,7 @@ module Snail.Lexer (
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void
+import Snail.Ast
 import Snail.Characters
 import Text.Megaparsec hiding (token)
 import Text.Megaparsec.Char
@@ -54,13 +52,6 @@ spaces = L.space space1 skipLineComment skipBlockComment
 symbol :: Text -> Parser Text
 symbol = L.symbol spaces
 
--- | The bracket used to sorround the s-expression
-data Bracket
-    = Round
-    | Square
-    | Curly
-    deriving (Show, Eq)
-
 roundP :: Parser a -> Parser (Bracket, a)
 roundP = fmap (Round,) . between (symbol "(") (symbol ")")
 
@@ -73,34 +64,6 @@ curly = fmap (Curly,) . between (symbol "{") (symbol "}")
 -- | Parse an S-Expression bracketed by 'Bracket'
 bracket :: Parser a -> Parser (Bracket, a)
 bracket inp = roundP inp <|> square inp <|> curly inp
-
-{-
-    A possibly empty tree of s-expressions
-
-    Technically,
-    @
-    Token (SourcePos {..}, "hello")
-    @
-
-    isn't a valid s-expression. This is,
-
-    @
-    SExpression [Token (SourcePos {..}, "hello")]
-    @
-
-    and this is also valid,
-
-    @
-    SExpression []
-    @
-
-    The 'Data.Tree.Tree' type in containers is non-empty which isn't exactly what we are looking for
--}
-data SnailAst
-    = Lexeme (SourcePos, Text)
-    | TextLiteral (SourcePos, Text)
-    | SExpression (Maybe Char) Bracket [SnailAst]
-    deriving (Eq, Show)
 
 {- | Any 'Text' object that starts with an appropriately valid character. This
  could be an variable or function name. For example, `hello` is a valid

--- a/src/Snail/ToText.hs
+++ b/src/Snail/ToText.hs
@@ -1,7 +1,7 @@
 module Snail.ToText (toText) where
 
 import Data.Text
-import Snail.Lexer
+import Snail.Ast
 
 bracket :: Text -> Bracket -> Text
 bracket txt = \case


### PR DESCRIPTION
In this PR, we add move the AST to a separate file and add the unwrap utility
handling nested s-expressions in your final case match.
