### PR TITLE
Explicitly handle some edge cases

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1690933134,
-        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1692741689,
-        "narHash": "sha256-CbNpheNJMTM9Wz5iTzdXmMtvfH9KvH/jNfv6N9roaqs=",
+        "lastModified": 1718653460,
+        "narHash": "sha256-8ana22BZaLp91gGvQq8YbfteJKFqza4qrqc6++bCnH4=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "c8622c8a259e18e0a1919462ce885380108a723c",
+        "rev": "569e28636c1aaee767a43741511fb36a6d3c284b",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693028636,
-        "narHash": "sha256-WOG42JO/yyvgYK3jQktDEy2qtZI7R+s3Lo4Y9gBr6XM=",
+        "lastModified": 1718606988,
+        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e61ea96d43505ba0d2c066134eb9d67cadfddce7",
+        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
         "type": "github"
       },
       "original": {
@@ -51,20 +51,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1690881714,
-        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
-        "type": "github"
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "root": {

--- a/package.yaml
+++ b/package.yaml
@@ -23,8 +23,8 @@ data-files:
 dependencies:
 - base >= 4.15 && < 5
 - containers >= 0.6.7 && < 0.7
-- megaparsec >= 9.3.1 && < 9.4
-- mtl >= 2.2.2 && < 2.3
+- megaparsec >= 9.5.0 && < 9.6
+- mtl >= 2.3.1 && < 2.4
 - QuickCheck >= 2.14.3 && < 2.15
 - text >= 2.0.2 && < 2.1
 - text-display >= 0.0.5 && < 0.1
@@ -50,8 +50,8 @@ tests:
     dependencies:
     - snail
     - HUnit >= 1.6.2 && < 1.7
-    - hspec >= 2.10.10 && < 2.11
-    - hspec-discover >= 2.10.10 && < 2.11
+    - hspec >= 2.11.8 && < 2.12
+    - hspec-discover >= 2.11.8 && < 2.12
     - raw-strings-qq >= 1.1 && < 1.2
 
 executable:

--- a/snail.cabal
+++ b/snail.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -60,8 +60,8 @@ library
       QuickCheck >=2.14.3 && <2.15
     , base >=4.15 && <5
     , containers >=0.6.7 && <0.7
-    , megaparsec >=9.3.1 && <9.4
-    , mtl >=2.2.2 && <2.3
+    , megaparsec >=9.5.0 && <9.6
+    , mtl >=2.3.1 && <2.4
     , text >=2.0.2 && <2.1
     , text-display >=0.0.5 && <0.1
   default-language: Haskell2010
@@ -82,8 +82,8 @@ executable snail
       QuickCheck >=2.14.3 && <2.15
     , base >=4.15 && <5
     , containers >=0.6.7 && <0.7
-    , megaparsec >=9.3.1 && <9.4
-    , mtl >=2.2.2 && <2.3
+    , megaparsec >=9.5.0 && <9.6
+    , mtl >=2.3.1 && <2.4
     , snail
     , text >=2.0.2 && <2.1
     , text-display >=0.0.5 && <0.1
@@ -112,10 +112,10 @@ test-suite snail-test
     , QuickCheck >=2.14.3 && <2.15
     , base >=4.15 && <5
     , containers >=0.6.7 && <0.7
-    , hspec >=2.10.10 && <2.11
-    , hspec-discover >=2.10.10 && <2.11
-    , megaparsec >=9.3.1 && <9.4
-    , mtl >=2.2.2 && <2.3
+    , hspec >=2.11.8 && <2.12
+    , hspec-discover >=2.11.8 && <2.12
+    , megaparsec >=9.5.0 && <9.6
+    , mtl >=2.3.1 && <2.4
     , raw-strings-qq ==1.1.*
     , snail
     , text >=2.0.2 && <2.1

--- a/src/Snail/Lexer.hs
+++ b/src/Snail/Lexer.hs
@@ -114,7 +114,7 @@ textLiteral = do
  recursively separated by 'spaces' in 'sExpression'.
 -}
 leaves :: Parser SnailAst
-leaves = lexeme <|> textLiteral <|> sExpression
+leaves = try sExpression <|> lexeme <|> textLiteral
 
 -- | Parse an 'SExpression'
 sExpression :: Parser SnailAst

--- a/test/Snail/LexerSpec.hs
+++ b/test/Snail/LexerSpec.hs
@@ -160,3 +160,15 @@ spec = do
 
         it "fails to parse nested mismatched brackets" $ do
             parseMaybe snailAst "([)]" `shouldSatisfy` isNothing
+
+        it "associates inner '#' with the s-expression" $ do
+            let Just [result] = parseMaybe snailAst "(different-char/2 #(inside))"
+            foldLexemes result `shouldBe` ["different-char/2", "inside"]
+
+        it "fails with two leading characters" $ do
+            parseMaybe snailAst "@,(foo)" `shouldSatisfy` isNothing
+
+        -- NOTE: this may or may not be the desired behavior
+        it "parses two leading characters as valid lexeme" $ do
+            let Just [result] = parseMaybe snailAst "(@,(foo ...))"
+            foldLexemes result `shouldBe` ["@,", "foo", "..."]


### PR DESCRIPTION
Closes #9 

I agree with that I expect the first example to parse the `#` as part of the s-expression. For the latter example though I think we should parse that as a valid lexeme (although I am not 100% convinced it is expected).

Additionally, I did `nix flake update` and bumped some package dependencies to make `nix build` work.